### PR TITLE
Support for Alloyed Collective DLC

### DIFF
--- a/InstancedLoot/Components/PingerControllerRenderBehaviour.cs
+++ b/InstancedLoot/Components/PingerControllerRenderBehaviour.cs
@@ -118,7 +118,7 @@ public class PingerControllerRenderBehaviour : InstancedLootBehaviour
 
             if (instanceHandler != null && instanceHandler.ObjectInstanceMode == ObjectInstanceMode.CopyObject)
             {
-                Highlight highlight = pingIndicator.pingHighlight;
+                //Highlight highlight = pingIndicator.pingHighlight;
 
                 Renderer targetRenderer = null;
                 
@@ -144,7 +144,7 @@ public class PingerControllerRenderBehaviour : InstancedLootBehaviour
                         : pingTarget.GetComponentInChildren<Renderer>();
                 }
 
-                highlight.targetRenderer = targetRenderer;
+                //highlight.targetRenderer = targetRenderer;
             }
         }
 

--- a/InstancedLoot/InstancedLoot.csproj
+++ b/InstancedLoot/InstancedLoot.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
 		<PackageReference Include="BepInEx.Core" Version="5.*" />
-		<PackageReference Include="RiskOfRain2.GameLibs" Version="1.3.6-r.0" />
+		<PackageReference Include="RiskOfRain2.GameLibs" Version="1.4.0-r.0" />
 		<PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
 		<PackageReference Include="MMHOOK.RoR2" Version="2024.12.10">
 			<NoWarn>NU1701</NoWarn>

--- a/InstancedLoot/ObjectHandlers/ChestHandler.cs
+++ b/InstancedLoot/ObjectHandlers/ChestHandler.cs
@@ -51,7 +51,7 @@ public class ChestHandler : AbstractObjectHandler
         
         targetChest.rng = new Xoroshiro128Plus(sourceChest.rng);
         targetChest.dropCount = sourceChest.dropCount;
-        targetChest.dropPickup = sourceChest.dropPickup;
+        targetChest.currentPickup = sourceChest.currentPickup;
         
         return base.InstanceSingleObjectFrom(source, target, players);
     }

--- a/InstancedLoot/ObjectHandlers/MultiShopHandler.cs
+++ b/InstancedLoot/ObjectHandlers/MultiShopHandler.cs
@@ -80,8 +80,8 @@ public class MultiShopHandler : AbstractObjectHandler
                 targetMultiShopController.Networkcost = sourceMultiShopController.Networkcost;
                 targetMultiShopController.rng = new Xoroshiro128Plus(sourceMultiShopController.rng);
 
-                var sourceTerminalGameObjects = sourceMultiShopController._terminalGameObjects;
-                var targetTerminalGameObjects = targetMultiShopController._terminalGameObjects;
+                var sourceTerminalGameObjects = sourceMultiShopController.terminalGameObjects;
+                var targetTerminalGameObjects = targetMultiShopController.terminalGameObjects;
 
                 for (int i = 0; i < targetTerminalGameObjects.Length; i++)
                     AwaitObjectFor(targetTerminalGameObjects[i],
@@ -99,7 +99,7 @@ public class MultiShopHandler : AbstractObjectHandler
 
                 targetShopTerminalBehavior.hasStarted = true;
                 targetShopTerminalBehavior.rng = new Xoroshiro128Plus(sourceShopTerminalBehavior.rng);
-                targetShopTerminalBehavior.NetworkpickupIndex = sourceShopTerminalBehavior.NetworkpickupIndex;
+                targetShopTerminalBehavior.Networkpickup = sourceShopTerminalBehavior.Networkpickup;
                 targetShopTerminalBehavior.Networkhidden = sourceShopTerminalBehavior.Networkhidden;
                 targetShopTerminalBehavior.UpdatePickupDisplayAndAnimations();
             }

--- a/InstancedLoot/ObjectHandlers/OptionChestHandler.cs
+++ b/InstancedLoot/ObjectHandlers/OptionChestHandler.cs
@@ -43,7 +43,7 @@ public class OptionChestHandler : AbstractObjectHandler
         OptionChestBehavior targetChest = target.GetComponent<OptionChestBehavior>();
         
         targetChest.rng = new Xoroshiro128Plus(sourceChest.rng); 
-        targetChest.generatedDrops = sourceChest.generatedDrops.ToArray();
+        targetChest.generatedPickups = sourceChest.generatedPickups;
         
         return base.InstanceSingleObjectFrom(source, target, players);
     }


### PR DESCRIPTION
The fixes added by this PR fix the mod to work with the changes added by the Alloyed Collective DLC. This is accomplished by updating `RiskOfRain2.GameLibs` from version 1.3.6 to version 1.4.0, and fixing the errors that resulted from doing so.